### PR TITLE
Reorder dependencies to sync with text

### DIFF
--- a/docs-source/docs/modules/cqrs/examples/shopping-cart-service-scala/build.sbt
+++ b/docs-source/docs/modules/cqrs/examples/shopping-cart-service-scala/build.sbt
@@ -17,18 +17,21 @@ lazy val `shopping-cart-service-scala` = project
     //tag::libraryDependencies[]
     libraryDependencies ++= Seq(
         "com.typesafe.akka" %% "akka-cluster-sharding-typed" % AkkaVersion,
+        "com.typesafe.akka" %% "akka-persistence-cassandra" % AkkaPersistenceCassandraVersion,
+        "com.lightbend.akka" %% "akka-projection-eventsourced" % AkkaProjectionVersion,
+        "com.lightbend.akka" %% "akka-projection-cassandra" % AkkaProjectionVersion,
+        "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion,
+        "com.typesafe.akka" %% "akka-http2-support" % AkkaHttpVersion,
+
         "com.typesafe.akka" %% "akka-persistence-typed" % AkkaVersion,
         "com.typesafe.akka" %% "akka-persistence-query" % AkkaVersion,
         "com.typesafe.akka" %% "akka-serialization-jackson" % AkkaVersion,
         "com.typesafe.akka" %% "akka-discovery" % AkkaVersion,
-        "com.typesafe.akka" %% "akka-persistence-cassandra" % AkkaPersistenceCassandraVersion,
-        "com.lightbend.akka" %% "akka-projection-eventsourced" % AkkaProjectionVersion,
-        "com.lightbend.akka" %% "akka-projection-cassandra" % AkkaProjectionVersion,
         "com.typesafe.akka" %% "akka-stream-kafka" % AlpakkaKafkaVersion,
-        "com.typesafe.akka" %% "akka-http" % AkkaHttpVersion,
-        "com.typesafe.akka" %% "akka-http2-support" % AkkaHttpVersion,
         "com.typesafe.akka" %% "akka-slf4j" % AkkaVersion,
+
         "ch.qos.logback" % "logback-classic" % "1.2.3",
+
         "com.typesafe.akka" %% "akka-actor-testkit-typed" % AkkaVersion % Test,
         "com.typesafe.akka" %% "akka-stream-testkit" % AkkaVersion % Test,
         "com.lightbend.akka" %% "akka-projection-testkit" % AkkaProjectionVersion % Test,


### PR DESCRIPTION
The page introducing the dependencies was a bit confusing:

<img width="884" alt="Screenshot 2020-08-19 at 20 42 20" src="https://user-images.githubusercontent.com/762126/90676578-87b6e380-e25c-11ea-922f-e40ab88f8ce3.png">


> This projects has four dependencies

And then

> Well, the list of dependencies is this wall of artifacts


This reordering is just a first step. Maybe some inline comments on the `build.sbt` would make the snippet more readable.