### PR TITLE
Connect to Kafka via Akka Discovery

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,15 +25,15 @@ jobs:
       env:
         DIR="docs-source/docs/modules/cqrs/examples/shopping-analytics-service-scala"
         CMD="Test/compile; scalafmtCheckAll"
-      name: "Compile and check code style."
+      name: "Shopping analytics service"
     - env:
         DIR="docs-source/docs/modules/cqrs/examples/shopping-cart-service-scala"
         CMD="Test/compile; scalafmtCheckAll"
-      name: "Compile and check code style."
+      name: "Shopping cart service"
     - env:
         DIR="docs-source/docs/modules/cqrs/examples/shopping-order-service-scala"
         CMD="Test/compile; scalafmtCheckAll"
-      name: "Compile and check code style."
+      name: "Shopping order service"
 
     - stage: site
       script:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ Example code
 
 The example projects used in the documentation are located at
 
-* [Akka Microservices (Event sourcing and CQRS) in Scala](docs-source/docs/modules/cqrs/examples/shopping-cart-service-scala)
+* [Shopping cart service in Scala](docs-source/docs/modules/cqrs/examples/shopping-cart-service-scala)
+* [Shopping cart analytics service in Scala](docs-source/docs/modules/cqrs/examples/shopping-analytics-service-scala)
+* [Order service in Scala](docs-source/docs/modules/cqrs/examples/shopping-order-service-scala)
 
 
 Antora-based Akka Documentation

--- a/docs-source/docs/modules/cqrs/examples/shopping-analytics-service-scala/src/main/resources/application.conf
+++ b/docs-source/docs/modules/cqrs/examples/shopping-analytics-service-scala/src/main/resources/application.conf
@@ -1,4 +1,5 @@
 include "cluster"
+include "kafka"
 
 akka {
   loglevel = DEBUG

--- a/docs-source/docs/modules/cqrs/examples/shopping-analytics-service-scala/src/main/resources/kafka.conf
+++ b/docs-source/docs/modules/cqrs/examples/shopping-analytics-service-scala/src/main/resources/kafka.conf
@@ -1,0 +1,27 @@
+akka {
+
+  discovery {
+    method = config
+
+    config.services = {
+      "shopping_kafka_service" = {
+        endpoints = [
+          { host = "localhost", port = 9092 }
+        ]
+      }
+    }
+
+  }
+}
+
+shopping-analytics {
+
+  shopping-cart-kafka-topic = "shopping_cart_events"
+
+  kafka.consumer: ${akka.kafka.consumer} {
+    service-name = "shopping_kafka_service"
+    kafka-clients {
+      auto.offset.reset = "earliest"
+    }
+  }
+}

--- a/docs-source/docs/modules/cqrs/examples/shopping-analytics-service-scala/src/main/scala/sample/shoppinganalytics/ShoppingCartEventConsumer.scala
+++ b/docs-source/docs/modules/cqrs/examples/shopping-analytics-service-scala/src/main/scala/sample/shoppinganalytics/ShoppingCartEventConsumer.scala
@@ -10,9 +10,9 @@ import akka.actor.typed.scaladsl.adapter._
 import akka.kafka.CommitterSettings
 import akka.kafka.ConsumerSettings
 import akka.kafka.Subscriptions
-import akka.kafka.scaladsl.{Committer, Consumer, DiscoverySupport}
+import akka.kafka.scaladsl.{ Committer, Consumer, DiscoverySupport }
 import akka.stream.scaladsl.RestartSource
-import com.google.protobuf.any.{Any => ScalaPBAny}
+import com.google.protobuf.any.{ Any => ScalaPBAny }
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.apache.kafka.common.serialization.ByteArrayDeserializer
 import org.apache.kafka.common.serialization.StringDeserializer

--- a/docs-source/docs/modules/cqrs/examples/shopping-analytics-service-scala/src/main/scala/sample/shoppinganalytics/ShoppingCartEventConsumer.scala
+++ b/docs-source/docs/modules/cqrs/examples/shopping-analytics-service-scala/src/main/scala/sample/shoppinganalytics/ShoppingCartEventConsumer.scala
@@ -4,17 +4,15 @@ import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.util.control.NonFatal
-
 import akka.Done
 import akka.actor.typed.ActorSystem
+import akka.actor.typed.scaladsl.adapter._
 import akka.kafka.CommitterSettings
 import akka.kafka.ConsumerSettings
 import akka.kafka.Subscriptions
-import akka.kafka.scaladsl.Committer
-import akka.kafka.scaladsl.Consumer
+import akka.kafka.scaladsl.{Committer, Consumer, DiscoverySupport}
 import akka.stream.scaladsl.RestartSource
-import com.google.protobuf.any.{ Any => ScalaPBAny }
-import org.apache.kafka.clients.consumer.ConsumerConfig
+import com.google.protobuf.any.{Any => ScalaPBAny}
 import org.apache.kafka.clients.consumer.ConsumerRecord
 import org.apache.kafka.common.serialization.ByteArrayDeserializer
 import org.apache.kafka.common.serialization.StringDeserializer
@@ -30,13 +28,11 @@ object ShoppingCartEventConsumer {
     implicit val ec: ExecutionContext = system.executionContext
 
     val topic = system.settings.config.getString("shopping-analytics.shopping-cart-kafka-topic")
-    val bootstrapServers = system.settings.config.getString("shopping-analytics.kafka-bootstrap-servers")
-    val config = system.settings.config.getConfig("akka.kafka.consumer")
+    val config = system.settings.config.getConfig("shopping-analytics.kafka.consumer")
     val consumerSettings =
       ConsumerSettings(config, new StringDeserializer, new ByteArrayDeserializer)
-        .withBootstrapServers(bootstrapServers)
+        .withEnrichAsync(DiscoverySupport.consumerBootstrapServers(config)(system.toClassic))
         .withGroupId("shopping-cart-analytics")
-        .withProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest")
     val committerSettings = CommitterSettings(system)
 
     RestartSource

--- a/docs-source/docs/modules/cqrs/examples/shopping-cart-service-scala/src/main/resources/application.conf
+++ b/docs-source/docs/modules/cqrs/examples/shopping-cart-service-scala/src/main/resources/application.conf
@@ -1,5 +1,6 @@
 include "cluster"
 include "persistence"
+include "kafka"
 
 # tag::cbor[]
 akka {

--- a/docs-source/docs/modules/cqrs/examples/shopping-cart-service-scala/src/main/resources/application.conf
+++ b/docs-source/docs/modules/cqrs/examples/shopping-cart-service-scala/src/main/resources/application.conf
@@ -21,7 +21,10 @@ shopping-cart {
 
   projection-parallelism = 4
 
-  grpc.port = 0
+  grpc {
+    interface = "127.0.0.1"
+    port = 0
+  }
   askTimeout = 5 s
 
   kafka-topic = "shopping_cart_events"
@@ -29,6 +32,9 @@ shopping-cart {
 }
 
 shopping-order {
-  grpc.port = 9051
+  grpc {
+    interface = "127.0.0.1"
+    port = 9051
+  }
 }
 

--- a/docs-source/docs/modules/cqrs/examples/shopping-cart-service-scala/src/main/resources/kafka.conf
+++ b/docs-source/docs/modules/cqrs/examples/shopping-cart-service-scala/src/main/resources/kafka.conf
@@ -1,0 +1,24 @@
+akka {
+
+  discovery {
+    method = config
+
+    config.services = {
+      "shopping_kafka_service" = {
+        endpoints = [
+          { host = "localhost", port = 9092 }
+        ]
+      }
+    }
+
+  }
+}
+
+shopping-cart {
+
+  shopping-cart-kafka-topic = "shopping_cart_events"
+
+  kafka.producer: ${akka.kafka.producer} {
+    service-name = "shopping_kafka_service"
+  }
+}

--- a/docs-source/docs/modules/cqrs/examples/shopping-cart-service-scala/src/main/scala/sample/shoppingcart/Main.scala
+++ b/docs-source/docs/modules/cqrs/examples/shopping-cart-service-scala/src/main/scala/sample/shoppingcart/Main.scala
@@ -72,6 +72,7 @@ object Guardian {
 class Guardian(context: ActorContext[Nothing]) extends AbstractBehavior[Nothing](context) {
   val system = context.system
 
+  val grpcInterface = system.settings.config.getString("shopping-cart.grpc.interface")
   val grpcPort = system.settings.config.getInt("shopping-cart.grpc.port")
   val projectionParallelism = system.settings.config.getInt("shopping-cart.projection-parallelism")
 
@@ -99,7 +100,7 @@ class Guardian(context: ActorContext[Nothing]) extends AbstractBehavior[Nothing]
     orderServiceClient
   }
 
-  ShoppingCartServer.start(grpcPort, system, itemPopularityRepository)
+  ShoppingCartServer.start(grpcInterface, grpcPort, system, itemPopularityRepository)
 
   override def onMessage(msg: Nothing): Behavior[Nothing] =
     this

--- a/docs-source/docs/modules/cqrs/examples/shopping-cart-service-scala/src/main/scala/sample/shoppingcart/PublishEventsProjection.scala
+++ b/docs-source/docs/modules/cqrs/examples/shopping-cart-service-scala/src/main/scala/sample/shoppingcart/PublishEventsProjection.scala
@@ -5,7 +5,7 @@ import akka.actor.typed.ActorSystem
 import akka.cluster.sharding.typed.ShardedDaemonProcessSettings
 import akka.cluster.sharding.typed.scaladsl.ShardedDaemonProcess
 import akka.kafka.ProducerSettings
-import akka.kafka.scaladsl.{DiscoverySupport, SendProducer}
+import akka.kafka.scaladsl.{ DiscoverySupport, SendProducer }
 import akka.persistence.cassandra.query.scaladsl.CassandraReadJournal
 import akka.persistence.query.Offset
 import akka.projection.ProjectionBehavior

--- a/docs-source/docs/modules/cqrs/examples/shopping-cart-service-scala/src/main/scala/sample/shoppingcart/PublishEventsProjection.scala
+++ b/docs-source/docs/modules/cqrs/examples/shopping-cart-service-scala/src/main/scala/sample/shoppingcart/PublishEventsProjection.scala
@@ -5,7 +5,7 @@ import akka.actor.typed.ActorSystem
 import akka.cluster.sharding.typed.ShardedDaemonProcessSettings
 import akka.cluster.sharding.typed.scaladsl.ShardedDaemonProcess
 import akka.kafka.ProducerSettings
-import akka.kafka.scaladsl.SendProducer
+import akka.kafka.scaladsl.{DiscoverySupport, SendProducer}
 import akka.persistence.cassandra.query.scaladsl.CassandraReadJournal
 import akka.persistence.query.Offset
 import akka.projection.ProjectionBehavior
@@ -40,10 +40,11 @@ object PublishEventsProjection {
 
   def init(system: ActorSystem[_], projectionParallelism: Int): Unit = {
     val topic = system.settings.config.getString("shopping-cart.kafka-topic")
-    val bootstrapServers = system.settings.config.getString("shopping-cart.kafka-bootstrap-servers")
-    val producerSettings =
-      ProducerSettings(system, new StringSerializer, new ByteArraySerializer).withBootstrapServers(bootstrapServers)
+    val config = system.settings.config.getConfig("shopping-cart.kafka.producer")
     import akka.actor.typed.scaladsl.adapter._ // FIXME might not be needed in later Alpakka Kafka version?
+    val producerSettings =
+      ProducerSettings(config, new StringSerializer, new ByteArraySerializer)
+        .withEnrichAsync(DiscoverySupport.producerBootstrapServers(config)(system.toClassic))
     val sendProducer = SendProducer(producerSettings)(system.toClassic)
 
     CoordinatedShutdown(system).addTask(CoordinatedShutdown.PhaseBeforeActorSystemTerminate, "close sendProducer") {

--- a/docs-source/docs/modules/cqrs/examples/shopping-cart-service-scala/src/main/scala/sample/shoppingcart/ShoppingCartServer.scala
+++ b/docs-source/docs/modules/cqrs/examples/shopping-cart-service-scala/src/main/scala/sample/shoppingcart/ShoppingCartServer.scala
@@ -15,7 +15,11 @@ import akka.http.scaladsl.model.HttpResponse
 
 object ShoppingCartServer {
 
-  def start(port: Int, system: ActorSystem[_], itemPopularityRepository: ItemPopularityRepository): Unit = {
+  def start(
+      interface: String,
+      port: Int,
+      system: ActorSystem[_],
+      itemPopularityRepository: ItemPopularityRepository): Unit = {
     implicit val sys: ActorSystem[_] = system
     implicit val ec: ExecutionContext = system.executionContext
 
@@ -26,7 +30,7 @@ object ShoppingCartServer {
         ServerReflection.partial(List(proto.ShoppingCartService)))
 
     val bound =
-      Http().newServerAt(interface = "127.0.0.1", port).bind(service).map(_.addToCoordinatedShutdown(3.seconds))
+      Http().newServerAt(interface, port).bind(service).map(_.addToCoordinatedShutdown(3.seconds))
 
     bound.onComplete {
       case Success(binding) =>

--- a/docs-source/docs/modules/cqrs/examples/shopping-cart-service-scala/src/test/scala/sample/shoppingcart/IntegrationSpec.scala
+++ b/docs-source/docs/modules/cqrs/examples/shopping-cart-service-scala/src/test/scala/sample/shoppingcart/IntegrationSpec.scala
@@ -4,7 +4,6 @@ import java.util.UUID
 
 import scala.concurrent.Future
 import scala.concurrent.duration._
-
 import akka.actor.testkit.typed.scaladsl.ActorTestKit
 import akka.actor.typed.ActorSystem
 import akka.actor.typed.Behavior
@@ -15,12 +14,12 @@ import akka.cluster.typed.Join
 import akka.grpc.GrpcClientSettings
 import akka.kafka.ConsumerSettings
 import akka.kafka.Subscriptions
-import akka.kafka.scaladsl.Consumer
+import akka.kafka.scaladsl.{Consumer, DiscoverySupport}
 import akka.persistence.typed.PersistenceId
 import akka.persistence.typed.scaladsl.Effect
 import akka.persistence.typed.scaladsl.EventSourcedBehavior
 import akka.testkit.SocketUtil
-import com.google.protobuf.any.{ Any => ScalaPBAny }
+import com.google.protobuf.any.{Any => ScalaPBAny}
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
 import org.apache.kafka.common.serialization.ByteArrayDeserializer
@@ -72,9 +71,13 @@ object IntegrationSpec {
       akka.projection.cassandra.offset-store.keyspace = $keyspace
       
       shopping-cart.kafka-topic = "shopping_cart_events_$uniqueQualifier"
-      
+
+      shopping-cart.test.kafka.consumer: $${akka.kafka.consumer} {
+        service-name = "shopping_kafka_service"
+      }
+
       akka.http.server.preview.enable-http2 = on
-      
+
       akka.loglevel = DEBUG
       akka.actor.testkit.typed.single-expect-default = 5s
       # For LoggingTestKit
@@ -85,12 +88,15 @@ object IntegrationSpec {
 
   private def nodeConfig(grpcPort: Int): Config =
     ConfigFactory.parseString(s"""
-      shopping-cart.grpc.port = $grpcPort
+      shopping-cart.grpc {
+        interface = "localhost"
+        port = $grpcPort
+      }
       """)
 
   class TestNodeFixture(grpcPort: Int) {
     val testKit =
-      ActorTestKit("IntegrationSpec", nodeConfig(grpcPort).withFallback(IntegrationSpec.config))
+      ActorTestKit("IntegrationSpec", nodeConfig(grpcPort).withFallback(IntegrationSpec.config).resolve())
 
     def system: ActorSystem[_] = testKit.system
 
@@ -169,13 +175,13 @@ class IntegrationSpec
 
   private def initializeKafkaTopicProbe(): Unit = {
     implicit val sys: ActorSystem[_] = testNode1.system
-    val bootstrapServers = sys.settings.config.getString("shopping-cart.kafka-bootstrap-servers")
-    val config = sys.settings.config.getConfig("akka.kafka.consumer")
     val topic = sys.settings.config.getString("shopping-cart.kafka-topic")
+    val config = sys.settings.config.getConfig("shopping-cart.test.kafka.consumer")
     val groupId = UUID.randomUUID().toString
+    import akka.actor.typed.scaladsl.adapter._ // FIXME might not be needed in later Alpakka Kafka version?
     val consumerSettings =
       ConsumerSettings(config, new StringDeserializer, new ByteArrayDeserializer)
-        .withBootstrapServers(bootstrapServers)
+        .withEnrichAsync(DiscoverySupport.consumerBootstrapServers(config)(sys.toClassic))
         .withGroupId(groupId)
     Consumer
       .plainSource(consumerSettings, Subscriptions.topics(topic))

--- a/docs-source/docs/modules/cqrs/examples/shopping-cart-service-scala/src/test/scala/sample/shoppingcart/IntegrationSpec.scala
+++ b/docs-source/docs/modules/cqrs/examples/shopping-cart-service-scala/src/test/scala/sample/shoppingcart/IntegrationSpec.scala
@@ -14,12 +14,12 @@ import akka.cluster.typed.Join
 import akka.grpc.GrpcClientSettings
 import akka.kafka.ConsumerSettings
 import akka.kafka.Subscriptions
-import akka.kafka.scaladsl.{Consumer, DiscoverySupport}
+import akka.kafka.scaladsl.{ Consumer, DiscoverySupport }
 import akka.persistence.typed.PersistenceId
 import akka.persistence.typed.scaladsl.Effect
 import akka.persistence.typed.scaladsl.EventSourcedBehavior
 import akka.testkit.SocketUtil
-import com.google.protobuf.any.{Any => ScalaPBAny}
+import com.google.protobuf.any.{ Any => ScalaPBAny }
 import com.typesafe.config.Config
 import com.typesafe.config.ConfigFactory
 import org.apache.kafka.common.serialization.ByteArrayDeserializer

--- a/docs-source/docs/modules/cqrs/examples/shopping-order-service-scala/src/main/resources/application.conf
+++ b/docs-source/docs/modules/cqrs/examples/shopping-order-service-scala/src/main/resources/application.conf
@@ -7,6 +7,9 @@ akka {
 akka.http.server.preview.enable-http2 = on
 
 shopping-order {
-  grpc.port = 0
+  grpc {
+    interface = "127.0.0.1"
+    port = 0
+  }
 }
 

--- a/docs-source/docs/modules/cqrs/examples/shopping-order-service-scala/src/main/scala/sample/shoppingorder/Main.scala
+++ b/docs-source/docs/modules/cqrs/examples/shopping-order-service-scala/src/main/scala/sample/shoppingorder/Main.scala
@@ -41,8 +41,9 @@ object Guardian {
     Behaviors.setup[Nothing] { context =>
       val system = context.system
 
+      val grpcInterface = context.system.settings.config.getString("shopping-order.grpc.interface")
       val grpcPort = context.system.settings.config.getInt("shopping-order.grpc.port")
-      new ShoppingOrderServer(grpcPort, system).start()
+      new ShoppingOrderServer(grpcInterface, grpcPort, system).start()
 
       Behaviors.empty
     }

--- a/docs-source/docs/modules/cqrs/examples/shopping-order-service-scala/src/main/scala/sample/shoppingorder/ShoppingOrderServer.scala
+++ b/docs-source/docs/modules/cqrs/examples/shopping-order-service-scala/src/main/scala/sample/shoppingorder/ShoppingOrderServer.scala
@@ -13,7 +13,7 @@ import akka.http.scaladsl.Http
 import akka.http.scaladsl.model.HttpRequest
 import akka.http.scaladsl.model.HttpResponse
 
-class ShoppingOrderServer(port: Int, system: ActorSystem[_]) {
+class ShoppingOrderServer(interface: String, port: Int, system: ActorSystem[_]) {
   private implicit val sys: ActorSystem[_] = system
   private implicit val ec: ExecutionContext = system.executionContext
 
@@ -26,7 +26,7 @@ class ShoppingOrderServer(port: Int, system: ActorSystem[_]) {
         ServerReflection.partial(List(proto.ShoppingOrderService)))
 
     val bound =
-      Http().newServerAt(interface = "127.0.0.1", port).bind(service).map(_.addToCoordinatedShutdown(3.seconds))
+      Http().newServerAt(interface, port).bind(service).map(_.addToCoordinatedShutdown(3.seconds))
 
     bound.onComplete {
       case Success(binding) =>


### PR DESCRIPTION
Use Akka Discovery to configure the Kafka bootstrap addresses.
For now, this uses config which makes it look much worse than the simple bootstrap-servers value.

Even moved the gRPC interface to the configuration files.

References #33
