### PR TITLE
fix IntegrationSpec, caused by rename of shopping-kafka-broker

### DIFF
--- a/docs-source/docs/modules/cqrs/examples/shopping-cart-service-scala/src/test/scala/sample/shoppingcart/IntegrationSpec.scala
+++ b/docs-source/docs/modules/cqrs/examples/shopping-cart-service-scala/src/test/scala/sample/shoppingcart/IntegrationSpec.scala
@@ -74,7 +74,7 @@ object IntegrationSpec {
       shopping-cart.kafka-topic = "shopping_cart_events_$uniqueQualifier"
 
       shopping-cart.test.kafka.consumer: $${akka.kafka.consumer} {
-        service-name = "shopping_kafka_service"
+        service-name = "shopping-kafka-broker"
       }
 
       akka.http.server.preview.enable-http2 = on


### PR DESCRIPTION
Fixes #62
