### PR TITLE
Make Antora site build from git sources

### DIFF
--- a/docs-source/author-mode-site.yml
+++ b/docs-source/author-mode-site.yml
@@ -1,12 +1,13 @@
 site:
-  title: "Akka Samples Site"
-  url: https://akka.io/akka-samples
+  title: "Akka Platform Guide"
+  url: https://akka.io/akka-platform-guide
   
 content:
   sources:
   - url: ./../
+    start-paths:
+    - docs-source/docs
     branches: [HEAD]
-    start-path: docs-source/docs
 
 
 ui:

--- a/docs-source/site.yml
+++ b/docs-source/site.yml
@@ -4,10 +4,10 @@ site:
   
 content:
   sources:
-  - url: git@github.com:akka/akka-mircoservices-samples.git
-    start-paths: 
-      - docs-source/docs
-    branches: [2.6]
+  - url: git@github.com:akka/akka-microservices-samples.git
+    start-paths:
+    - docs-source/docs
+    branches: [main]
 
 ui: 
   bundle:


### PR DESCRIPTION
This makes the `make` command work and it will produce the site from the current state of `main`.

`make html-author-mode` continues to show the latest local changes including all TODO and REVIEW sections.
